### PR TITLE
Add go module to support go (and s2i builder) 1.16+

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/sclorg/golang-ex
+
+go 1.11


### PR DESCRIPTION
This fixes an issue that the latest version of go, and with this also the latest version of s2i could not build this repository anymore. And the OpenShift console uses this repo as an (interactive) example:

![image](https://user-images.githubusercontent.com/139310/157834194-eb0be768-427e-4e2e-ab26-ccf5a27c36d8.png)

Thanks to @rottencandy who found this issue while testing the latest OpenShift release.

We got this error when building it with Go Builder Image 1.16.7 (UBI 7) and Go 1.16.7 (UBI 8):

![image](https://user-images.githubusercontent.com/139310/157834349-26a1f41b-9ec6-41f6-bf29-0786905ddd0d.png)

```
go: cannot find main module, but found .git/config in /tmp/src
to create a module there, run:
go mod init
```

The latest go documentation on https://go.dev/ref/mod says:

> A go.mod file is required for the [main module](https://go.dev/ref/mod#glos-main-module), and for any [replacement module](https://go.dev/ref/mod#go-mod-file-replace) specified with a local file path. However, a module that lacks an explicit go.mod file may still be [required](https://go.dev/ref/mod#go-mod-file-require) as a dependency, or used as a replacement specified with a module path and version; see [Compatibility with non-module repositories](https://go.dev/ref/mod#non-module-compat).

I could verify that `go run .` (or build) without a module file doesn't work anymore, starting with 1.16.

`go run hello_openshift.go` still works fine, but is no option for our s2i build.

```
$HOME/go/bin/go1.11 run .
serving on 8888
serving on 10010
^Csignal: interrupt

$HOME/go/bin/go1.12 run .
serving on 8888
serving on 10010
^Csignal: interrupt

$HOME/go/bin/go1.13 run .
serving on 8888
serving on 10010
^Csignal: interrupt

$HOME/go/bin/go1.14 run .
serving on 8888
serving on 10010
^Csignal: interrupt

$HOME/go/bin/go1.15 run .
serving on 8888
serving on 10010
^Csignal: interrupt

$HOME/go/bin/go1.16 run .
go: cannot find main module, but found .git/config in /home/christoph/git/sclorg/golang-ex
	to create a module there, run:
	go mod init

HOME/go/bin/go1.17 run .
go: cannot find main module, but found .git/config in /home/christoph/git/sclorg/golang-ex
	to create a module there, run:
	go mod init
```

With this go module:

```
$HOME/go/bin/go1.11 run .   
serving on 8888
serving on 10010
^Csignal: interrupt

$HOME/go/bin/go1.12 run . 
serving on 8888
serving on 10010
^Csignal: interrupt

$HOME/go/bin/go1.13 run . 
serving on 8888
serving on 10010
^Csignal: interrupt

$HOME/go/bin/go1.14 run . 
serving on 8888
serving on 10010
^Csignal: interrupt

$HOME/go/bin/go1.15 run . 
serving on 8888
serving on 10010
^Csignal: interrupt

$HOME/go/bin/go1.16 run . 
serving on 8888
serving on 10010
^Csignal: interrupt

$HOME/go/bin/go1.17 run . 
serving on 8888
serving on 10010
^Csignal: interrupt
```
